### PR TITLE
Made GraphCut faster

### DIFF
--- a/src/algorithms/jet_refiner.rs
+++ b/src/algorithms/jet_refiner.rs
@@ -305,6 +305,7 @@ fn jetrw(graph: &Graph, partitions: &[usize], vertex_weights: &[i64], vertex_con
 
 fn lock_vertices(moves: &Vec<Move>, locked_vertices: &mut [bool]) {
     // This function gets the list of locked vertices that shouldn't be moved in the subsequent iterations.
+    locked_vertices.fill(false);
 
     for single_move in moves{
         locked_vertices[single_move.vertex] = true;

--- a/src/algorithms/jet_refiner.rs
+++ b/src/algorithms/jet_refiner.rs
@@ -41,7 +41,6 @@ fn jet_refiner(
     debug_assert_eq!(partition.len(), weights.len());
     debug_assert_eq!(partition.len(), adjacency.len());
 
-    let mut partition_best = partition.to_vec();
     let mut partition_iter = partition.to_vec();
     let mut current_iteration = 0;
     let num_of_partitions = partition.iter().collect::<HashSet<_>>().len();
@@ -82,8 +81,8 @@ fn jet_refiner(
                                              moves);
 
         let imbalance_of_current_iter_partition = imbalance(num_of_partitions, &partition_iter, weights.par_iter().cloned());
-        let imbalance_of_best_partition = imbalance(num_of_partitions, &partition_best, weights.par_iter().cloned());
-        let best_partition_edge_cut = adjacency.edge_cut(&partition_best);
+        let imbalance_of_best_partition = imbalance(num_of_partitions, &partition, weights.par_iter().cloned());
+        let best_partition_edge_cut = adjacency.edge_cut(&partition);
         let curr_iter_partition_edge_cut = adjacency.edge_cut(&partition_iter);
 
         // Check if the current iteration partition is balance
@@ -94,21 +93,19 @@ fn jet_refiner(
                 if curr_iter_partition_edge_cut < (tolerance_factor*(best_partition_edge_cut as f64)).floor() as i64 {
                     current_iteration = 0;
                 }
-                partition_best = partition_iter.to_vec();
+                partition.copy_from_slice(&partition_iter);
             } else {
                 current_iteration += 1;
             }
         } else if imbalance_of_current_iter_partition < imbalance_of_best_partition {
             // Current iteration is better balanced than the best iteration, hence this is made
             // the best iteration
-            partition_best = partition_iter.to_vec();
+            partition.copy_from_slice(&partition_iter);
             current_iteration = 0
         } else {
             current_iteration += 1;
         }
     }
-
-    partition.copy_from_slice(&partition_best);
 }
 
 fn jetlp(graph: &Graph, partition: &[usize], vertex_connectivity_data_structure: &Vec<HashMap<usize, i64>>, locked_vertices: &[bool], filter_ratio: f64) -> Vec<Move> {

--- a/src/algorithms/jet_refiner.rs
+++ b/src/algorithms/jet_refiner.rs
@@ -167,6 +167,7 @@ fn jetlp(graph: &Graph, partition: &[usize], vertex_connectivity_data_structure:
 
     // A heuristic attempt is made to approximate the true gain that would occur since
     // two positive moves when applied simultaneously can be detrimental.
+    let first_filter_eligible_vertices = first_filter_eligible_moves.clone().into_iter().collect::<HashSet<_>>();
     let gain2: Vec<i64> = (0..first_filter_eligible_moves.len()).into_par_iter().map(|vertex_index|{
         let vertex = first_filter_eligible_moves[vertex_index];
         let mut gain_for_vertex = 0;
@@ -174,7 +175,7 @@ fn jetlp(graph: &Graph, partition: &[usize], vertex_connectivity_data_structure:
         for (neighbor_vertex, edge_weight) in graph.neighbors(vertex){
             let mut partition_source = partition[neighbor_vertex];
 
-            if is_higher_placed(neighbor_vertex, vertex, &gain, &first_filter_eligible_moves) {
+            if is_higher_placed(neighbor_vertex, vertex, &gain, &first_filter_eligible_vertices) {
                 partition_source = partition_dest[neighbor_vertex];
             }
 
@@ -420,7 +421,7 @@ fn update_parts_and_vertex_connectivity(
     }
 }
 
-fn is_higher_placed(vertex1: usize, vertex2: usize, gain: &[i64], list_of_vertices: &[usize]) -> bool {
+fn is_higher_placed(vertex1: usize, vertex2: usize, gain: &[i64], list_of_vertices: &HashSet<usize>) -> bool {
     // Checks if vertex1 is better ranked than vertex2 (used in the vertex afterburner).
 
     if list_of_vertices.contains(&vertex1) && (gain[vertex1] > gain[vertex2] || (gain[vertex1] == gain[vertex2] && vertex1 < vertex2)){
@@ -765,7 +766,7 @@ mod tests {
     fn test_is_higher_placed(){
         // Arrange
         let gain = [4, 2, 2, 1];
-        let list_of_vertices = [0, 1, 2];
+        let list_of_vertices = [0, 1, 2].into_iter().collect();
 
         // Act
         let result1 = is_higher_placed(0, 2, &gain, &list_of_vertices);

--- a/src/algorithms/multilevel_partitioner.rs
+++ b/src/algorithms/multilevel_partitioner.rs
@@ -84,12 +84,13 @@ fn multilevel_partitioner(
 fn heavy_edge_matching_coarse(graph: &Graph, rng: &mut StdRng, weights: &[i64]) -> (Graph, Vec<Vec<usize>>, Vec<i64>) {
 
     let mut matched_nodes = vec![0; graph.len()];
-    let mut vertex_mapping = Vec::new();
+    let mut vertex_mapping = Vec::with_capacity(graph.len());
     let mut old_vertex_to_new_vertex =  vec![0; graph.len()];
 
     let mut vertices: Vec<usize> = (0..graph.len()).collect();
     vertices.shuffle(rng);
     let mut super_vertex = 0usize;
+    let mut num_of_edges = graph.graph_csr.nnz();
 
     // Iterate over the vertices of the graph.
     for vertex in vertices{
@@ -123,6 +124,7 @@ fn heavy_edge_matching_coarse(graph: &Graph, rng: &mut StdRng, weights: &[i64]) 
             // This will come in handy during the reconstruction of the coarse graph.
             old_vertex_to_new_vertex[vertex] = super_vertex;
             old_vertex_to_new_vertex[heaviest_edge_connected_vertice.unwrap()] = super_vertex;
+            num_of_edges -= 1;
         } else {
             // This flow is for the scenario when a vertex has no vertex to merge with.
             // (mostly because all of its neighbors are already matched)
@@ -137,7 +139,7 @@ fn heavy_edge_matching_coarse(graph: &Graph, rng: &mut StdRng, weights: &[i64]) 
     // Eg. If vertex 0 is connected to vertex 2 and vertex 3 which is merged into vertex 1 in the
     // coarse graph, then in the coarse graph vertex 0 will be connected to vertex 1 with
     // an edge length that is tge sum of vertex 0 and vertex 2 and vertex 0 and vertex 3
-    let mut edge_to_weight_mapping = HashMap::new();
+    let mut edge_to_weight_mapping = HashMap::with_capacity(num_of_edges);
 
     for vertex in 0..graph.len() {
         for (neighbor, edge_weight) in graph.neighbors(vertex){

--- a/src/algorithms/multilevel_partitioner.rs
+++ b/src/algorithms/multilevel_partitioner.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap};
 use std::io::{Write};
-use std::time::Instant;
 use rand::seq::SliceRandom;
 use rand::{SeedableRng};
 use rand::rngs::StdRng;
@@ -152,7 +151,8 @@ fn heavy_edge_matching_coarse(graph: &Graph, rng: &mut StdRng, weights: &[i64]) 
         }
     }
 
-    // Construction of the coarse graph.
+    // Construction of the coarse graph. First contruct a TriMat and then convert it to CSR format.
+    // This is more efficient.
     let mut new_coarse_graph  = Graph::new();
     let mut triplet_matrix = TriMat::with_capacity((super_vertex, super_vertex), num_of_edges);
 
@@ -438,19 +438,4 @@ mod tests {
         let uncoarse_graph_imbalance = imbalance(2, &uncoarsed_graph_partition, weights_uncoarse_graph.clone());
         assert!((coarse_graph_imbalance - uncoarse_graph_imbalance).abs() < epsilon);
     }
-
-    #[test]
-    fn test_ml() -> Result<(), Box<dyn std::error::Error>> {
-        let graph = read_matrix_market_as_graph(Path::new("./testdata/vt2010.mtx"));
-        let weights = gen_uniform_weights(graph.len());
-        let mut partition = vec![0; graph.len()];
-        let start = Instant::now();
-        MultiLevelPartitioner {jet_iterations: 12, ..Default::default()}.partition(&mut partition, (graph.clone(), &weights))?;
-        let elapsed = start.elapsed();
-        let edge_cut = graph.edge_cut(&partition);
-        println!("Edge cut {:?}", edge_cut);
-        println!("elapsed time {:?}", elapsed);
-        Ok(())
-    }
-
 }

--- a/src/algorithms/multilevel_partitioner.rs
+++ b/src/algorithms/multilevel_partitioner.rs
@@ -10,7 +10,7 @@ use crate::imbalance::imbalance;
 
 fn multilevel_partitioner(
     partition: &mut [usize],
-    weights: &[f64],
+    weights: &[i64],
     graph: Graph,
     fa2_iterations: u32,
     jet_iterations: u32,
@@ -27,7 +27,7 @@ fn multilevel_partitioner(
     let mut weights_of_coarse_graph_after_operation = weights.to_vec();
 
     // Keep coarsening the graph until the graph has less than 100 nodes
-    while coarse_graph_after_operation.len() > 100  {
+    while coarse_graph_after_operation.len() > 20  {
 
         let (coarse_graph, vertex_mapping, weights_of_coarse_graph) = heavy_edge_matching_coarse(&coarse_graph_after_operation, None, &weights_of_coarse_graph_after_operation);
         coarse_graph_after_operation = coarse_graph.clone();
@@ -73,7 +73,7 @@ fn multilevel_partitioner(
 }
 
 // This function coarsens the graph using heavy edge matching algorithm.
-fn heavy_edge_matching_coarse(graph: &Graph, seed: Option<u64>, weights: &[f64]) -> (Graph, Vec<Vec<usize>>, Vec<f64>) {
+fn heavy_edge_matching_coarse(graph: &Graph, seed: Option<u64>, weights: &[i64]) -> (Graph, Vec<Vec<usize>>, Vec<i64>) {
 
     let mut rng = match seed {
         Some(seed) => StdRng::seed_from_u64(seed),
@@ -86,8 +86,8 @@ fn heavy_edge_matching_coarse(graph: &Graph, seed: Option<u64>, weights: &[f64])
 
     let mut vertices: Vec<usize> = (0..graph.len()).collect();
     vertices.shuffle(&mut rng);
-
     let mut super_vertex = 0usize;
+
     // Iterate over the vertices of the graph.
     for vertex in vertices{
         // If already matched, then ignore
@@ -96,7 +96,7 @@ fn heavy_edge_matching_coarse(graph: &Graph, seed: Option<u64>, weights: &[f64])
         }
         // For each vertice, finds its most connected vertice, i.e the vertice that
         // is connected with the greatest edge weight
-        let mut heaviest_edge_weight = 0f64;
+        let mut heaviest_edge_weight = 0;
         let mut heaviest_edge_connected_vertice = None;
 
         for (neighbor_vertex, edge_weight) in graph.neighbors(vertex){
@@ -134,30 +134,62 @@ fn heavy_edge_matching_coarse(graph: &Graph, seed: Option<u64>, weights: &[f64])
     // Eg. If vertex 0 is connected to vertex 2 and vertex 3 which is merged into vertex 1 in the
     // coarse graph, then in the coarse graph vertex 0 will be connected to vertex 1 with
     // an edge length that is tge sum of vertex 0 and vertex 2 and vertex 0 and vertex 3
-    let mut edge_to_weight_mapping = HashMap::new();
+    // let mut edge_to_weight_mapping = HashMap::new();
+    //
+    // for vertex in 0..graph.len() {
+    //     for (neighbor, edge_weight) in graph.neighbors(vertex){
+    //         if old_vertex_to_new_vertex[vertex] != old_vertex_to_new_vertex[neighbor] {
+    //             let key = (old_vertex_to_new_vertex[vertex], old_vertex_to_new_vertex[neighbor]);
+    //             let total_edge_weight = edge_to_weight_mapping.entry(key).or_insert(0);
+    //             *total_edge_weight += edge_weight;
+    //         }
+    //     }
+    // }
+    //
+    // // Construction of the coarse graph.
+    // let mut new_coarse_graph  = Graph::new();
+    //
+    // for key in edge_to_weight_mapping.keys(){
+    //     let(vertex1, vertex2) = *key;
+    //     let edge_weight = edge_to_weight_mapping.get(key).unwrap();
+    //
+    //     new_coarse_graph.insert(vertex1, vertex2, *edge_weight);
+    // }
+
+    let mut new_coarse_graph = Graph::new();
 
     for vertex in 0..graph.len() {
         for (neighbor, edge_weight) in graph.neighbors(vertex){
             if old_vertex_to_new_vertex[vertex] != old_vertex_to_new_vertex[neighbor] {
-                let key = (old_vertex_to_new_vertex[vertex], old_vertex_to_new_vertex[neighbor]);
-                let total_edge_weight = edge_to_weight_mapping.entry(key).or_insert(0f64);
-                *total_edge_weight += edge_weight;
+                // let key = (old_vertex_to_new_vertex[vertex], old_vertex_to_new_vertex[neighbor]);
+                // let total_edge_weight = edge_to_weight_mapping.entry(key).or_insert(0);
+                // *total_edge_weight += edge_weight;
+
+                let edge_weight_of_coarse_graph = new_coarse_graph.get_edge_weight(old_vertex_to_new_vertex[vertex],
+                                                                                   old_vertex_to_new_vertex[neighbor]);
+
+                match edge_weight_of_coarse_graph {
+                    Some(edge_weight_of_coarse_graph) => {
+                        new_coarse_graph.insert(old_vertex_to_new_vertex[vertex],
+                                                old_vertex_to_new_vertex[neighbor],
+                                                edge_weight_of_coarse_graph + edge_weight);
+                    }
+                    None => {
+                        new_coarse_graph.insert(old_vertex_to_new_vertex[vertex],
+                                                old_vertex_to_new_vertex[neighbor],
+                                                edge_weight);
+                    }
+                }
+
             }
         }
     }
 
-    // Construction of the coarse graph.
-    let mut new_coarse_graph  = Graph::new();
 
-    for key in edge_to_weight_mapping.keys(){
-        let(vertex1, vertex2) = *key;
-        let edge_weight = edge_to_weight_mapping.get(key).unwrap();
 
-        new_coarse_graph.insert(vertex1, vertex2, *edge_weight);
-    }
 
     // Construction of the weights array for the coarse graph.
-    let mut weights_coarse_graph = vec![0f64; new_coarse_graph.len()];
+    let mut weights_coarse_graph = vec![0; new_coarse_graph.len()];
 
     for coarse_vertex in 0..vertex_mapping.len(){
         for uncoarse_vertex in vertex_mapping[coarse_vertex].iter(){
@@ -193,20 +225,20 @@ fn partition_uncoarse(partition: &[usize], vertex_mapping: &Vec<Vec<usize>>) -> 
 }
 
 // This function computes 2D coordinates for graph nodes using forceatlas2 algorithm.
-fn convert_graph_to_coordinates(graph: &Graph, weights: Vec<f64>, iter:u32) -> Vec<Point2D> {
+fn convert_graph_to_coordinates(graph: &Graph, weights: Vec<i64>, iter:u32) -> Vec<Point2D> {
     // Create a vector where the elements are in the structure ((vertex1, vertex2), edge_weight).
     let mut edges = Vec::new();
 
     for node in 0..graph.len() {
         for (neighbor_node, edge_weight) in graph.neighbors(node) {
-            edges.push(((node, neighbor_node), edge_weight));
+            edges.push(((node, neighbor_node), edge_weight as f64));
         }
     }
 
     // Run forceatlas2 for the graph to generate the coordinates.
     let mut layout = forceatlas2::Layout::<f64, 2>::from_graph_with_degree_mass(
         edges,
-        weights,
+        weights.iter().map(|&x| x as f64).collect::<Vec<f64>>(),
         forceatlas2::Settings{strong_gravity: true , ..Default::default()},
     );
 
@@ -239,7 +271,7 @@ fn convert_graph_to_coordinates(graph: &Graph, weights: Vec<f64>, iter:u32) -> V
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///
 ///     let graph = read_matrix_market_as_graph(Path::new("./testdata/vt2010.mtx"));
-///     let weights = gen_random_weights(graph.len(), 1.0, 3.0);
+///     let weights = gen_random_weights(graph.len(), 1, 3);
 ///     let mut partition = vec![0; graph.len()];
 ///
 ///     MultiLevelPartitioner {..Default::default()}.partition(&mut partition, (graph.clone(), &weights))?;
@@ -280,7 +312,7 @@ impl Default for MultiLevelPartitioner {
     fn default() -> Self {
         MultiLevelPartitioner {
             fa2_iterations: 100,
-            jet_iterations: 4,
+            jet_iterations: 12,
             balance_factor: 0.1,
             jet_filter_ratio: 0.75,
             jet_tolerance_factor: 0.99,
@@ -288,14 +320,14 @@ impl Default for MultiLevelPartitioner {
     }
 }
 
-impl<'a> Partition<(Graph, &'a [f64])> for MultiLevelPartitioner {
+impl<'a> Partition<(Graph, &'a [i64])> for MultiLevelPartitioner {
     type Metadata = ();
     type Error = Error;
 
     fn partition(
         &mut self,
         part_ids: &mut [usize],
-        (adjacency, weights): (Graph, &'a [f64]),
+        (adjacency, weights): (Graph, &'a [i64]),
     ) -> Result<Self::Metadata, Self::Error> {
 
         if part_ids.len() != weights.len() {
@@ -328,7 +360,7 @@ impl<'a> Partition<(Graph, &'a [f64])> for MultiLevelPartitioner {
 mod tests {
     use std::path::Path;
     use std::time::Instant;
-    use crate::gen_weights::gen_random_weights;
+    use crate::gen_weights::{gen_random_weights, gen_uniform_weights};
     use crate::io::read_matrix_market_as_graph;
     use super::*;
 
@@ -336,15 +368,15 @@ mod tests {
     fn test_3_node_heavy_edge_matching_coarse() {
         // Arrange
         let mut graph = Graph::new();
-        graph.insert(0, 1, 5.);
-        graph.insert(0, 2, 10.);
-        graph.insert(1, 2, 15.);
+        graph.insert(0, 1, 5);
+        graph.insert(0, 2, 10);
+        graph.insert(1, 2, 15);
 
-        graph.insert(1, 0, 5.);
-        graph.insert(2, 0, 10.);
-        graph.insert(2, 1, 15.);
+        graph.insert(1, 0, 5);
+        graph.insert(2, 0, 10);
+        graph.insert(2, 1, 15);
 
-        let weights = [3.0, 4.0, 5.0];
+        let weights = [3, 4, 5];
         let seed = Some(5);
 
         // Act
@@ -352,8 +384,8 @@ mod tests {
 
 
         // Assert
-        assert_eq!(15., coarse_graph.get_edge_weight(0, 1).unwrap());
-        assert_eq!(15., coarse_graph.get_edge_weight(1, 0).unwrap());
+        assert_eq!(15, coarse_graph.get_edge_weight(0, 1).unwrap());
+        assert_eq!(15, coarse_graph.get_edge_weight(1, 0).unwrap());
 
         assert!(coarse_graph.get_edge_weight(0, 0).is_none());
         assert!(coarse_graph.get_edge_weight(1, 1).is_none());
@@ -361,41 +393,41 @@ mod tests {
         assert_eq!(vertex_mapping[0], vec![1, 2]);
         assert_eq!(vertex_mapping[1], vec![0]);
 
-        assert_eq!(weights_coarse_graph, vec![9.0, 3.0]);
+        assert_eq!(weights_coarse_graph, vec![9, 3]);
     }
 
     #[test]
     fn test_5_node_heavy_edge_matching_coarse() {
         // Arrange
         let mut graph = Graph::new();
-        graph.insert(0, 1, 3.);
-        graph.insert(1, 2, 5.);
-        graph.insert(2, 3, 4.);
-        graph.insert(3, 4, 6.);
-        graph.insert(4, 0, 10.);
+        graph.insert(0, 1, 3);
+        graph.insert(1, 2, 5);
+        graph.insert(2, 3, 4);
+        graph.insert(3, 4, 6);
+        graph.insert(4, 0, 10);
 
-        graph.insert(1, 0, 3.);
-        graph.insert(2, 1, 5.);
-        graph.insert(3, 2, 4.);
-        graph.insert(4, 3, 6.);
-        graph.insert(0, 4, 10.);
+        graph.insert(1, 0, 3);
+        graph.insert(2, 1, 5);
+        graph.insert(3, 2, 4);
+        graph.insert(4, 3, 6);
+        graph.insert(0, 4, 10);
 
         let seed = Some(5);
 
-        let weights = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let weights = [1, 2, 3, 4, 5];
 
         // Act
         let (coarse_graph, vertex_mapping, weights_coarse_graph) = heavy_edge_matching_coarse(&graph, seed, &weights);
 
         // Assert
-        assert_eq!(6., coarse_graph.get_edge_weight(0, 1).unwrap());
-        assert_eq!(6., coarse_graph.get_edge_weight(1, 0).unwrap());
+        assert_eq!(6, coarse_graph.get_edge_weight(0, 1).unwrap());
+        assert_eq!(6, coarse_graph.get_edge_weight(1, 0).unwrap());
 
-        assert_eq!(3., coarse_graph.get_edge_weight(0, 2).unwrap());
-        assert_eq!(3., coarse_graph.get_edge_weight(2, 0).unwrap());
+        assert_eq!(3, coarse_graph.get_edge_weight(0, 2).unwrap());
+        assert_eq!(3, coarse_graph.get_edge_weight(2, 0).unwrap());
 
-        assert_eq!(5., coarse_graph.get_edge_weight(1, 2).unwrap());
-        assert_eq!(5., coarse_graph.get_edge_weight(2, 1).unwrap());
+        assert_eq!(5, coarse_graph.get_edge_weight(1, 2).unwrap());
+        assert_eq!(5, coarse_graph.get_edge_weight(2, 1).unwrap());
 
         assert!(coarse_graph.get_edge_weight(0, 0).is_none());
         assert!(coarse_graph.get_edge_weight(1, 1).is_none());
@@ -405,16 +437,16 @@ mod tests {
         assert_eq!(vertex_mapping[1], vec![2, 3]);
         assert_eq!(vertex_mapping[2], vec![1]);
 
-        assert_eq!(weights_coarse_graph, vec![6.0, 7.0, 2.0]);
+        assert_eq!(weights_coarse_graph, vec![6, 7, 2]);
     }
 
     #[test]
     fn test_partition_uncoarse() {
         // Arrange
         let vertex_mapping = vec![vec![0, 3], vec![2], vec![1]];
-        let weights_coarse_graph = [5.0, 7.0, 6.0];
+        let weights_coarse_graph = [5, 7, 6];
         let coarse_graph_partition = [1, 0, 0];
-        let weights_uncoarse_graph = [2.0, 6.0, 7.0, 3.0];
+        let weights_uncoarse_graph = [2, 6, 7, 3];
 
         // Act
         let uncoarsed_graph_partition = partition_uncoarse(&coarse_graph_partition, &vertex_mapping);
@@ -426,4 +458,19 @@ mod tests {
         let uncoarse_graph_imbalance = imbalance(2, &uncoarsed_graph_partition, weights_uncoarse_graph.clone());
         assert!((coarse_graph_imbalance - uncoarse_graph_imbalance).abs() < epsilon);
     }
+
+    #[test]
+    fn test_ml() -> Result<(), Box<dyn std::error::Error>> {
+        let graph = read_matrix_market_as_graph(Path::new("./testdata/vt2010.mtx"));
+        //let weights = gen_random_weights(graph.len(), 1, 3);
+        let weights = gen_uniform_weights(graph.len());
+        let mut partition = vec![0; graph.len()];
+
+        MultiLevelPartitioner {..Default::default()}.partition(&mut partition, (graph.clone(), &weights))?;
+
+        let edge_cut = graph.edge_cut(&partition);
+        println!("Edge cut {:?}", edge_cut);
+        Ok(())
+    }
+
 }

--- a/src/algorithms/multilevel_partitioner.rs
+++ b/src/algorithms/multilevel_partitioner.rs
@@ -35,7 +35,7 @@ fn multilevel_partitioner(
     };
 
     // Keep coarsening the graph until the graph has less than 100 nodes
-    while coarse_graph_after_operation.len() > 20  {
+    while coarse_graph_after_operation.len() > 100  {
 
         let (coarse_graph, vertex_mapping, weights_of_coarse_graph) = heavy_edge_matching_coarse(&coarse_graph_after_operation, &mut rng, &weights_of_coarse_graph_after_operation);
         coarse_graph_after_operation = coarse_graph.clone();

--- a/src/algorithms/multilevel_partitioner.rs
+++ b/src/algorithms/multilevel_partitioner.rs
@@ -154,7 +154,7 @@ fn heavy_edge_matching_coarse(graph: &Graph, rng: &mut StdRng, weights: &[i64]) 
 
     // Construction of the coarse graph.
     let mut new_coarse_graph  = Graph::new();
-    let mut triplet_matrix = TriMat::new((super_vertex, super_vertex));
+    let mut triplet_matrix = TriMat::with_capacity((super_vertex, super_vertex), num_of_edges);
 
     for key in edge_to_weight_mapping.keys(){
         let(vertex1, vertex2) = *key;

--- a/src/gen_weights.rs
+++ b/src/gen_weights.rs
@@ -1,22 +1,22 @@
 use rand::{Rng};
 
 /// Generate the weight vector where each vertice has the same weight
-pub fn gen_uniform_weights(no_of_vertices: usize) -> Vec<f64> {
-    vec![1.0; no_of_vertices]
+pub fn gen_uniform_weights(no_of_vertices: usize) -> Vec<i64> {
+    vec![1; no_of_vertices]
 }
 
 /// Generate the weight vector where each vertice has a random weight
-pub fn gen_random_weights(no_of_vertices: usize, min_weight: f64, max_weight: f64) -> Vec<f64> {
+pub fn gen_random_weights(no_of_vertices: usize, min_weight: i64, max_weight: i64) -> Vec<i64> {
     if(max_weight < min_weight) {
         panic!("Max weight must be greater than min weight.");
     }
 
-    if(max_weight < 0.0 || min_weight <= 0.0) {
+    if(max_weight < 0 || min_weight <= 0) {
         panic!("Max/min weight must be non-negative.");
     }
     let mut rng = rand::thread_rng();
 
-    let random_weights: Vec<f64> = (0..no_of_vertices)
+    let random_weights: Vec<i64> = (0..no_of_vertices)
         .map(|_| rng.gen_range(min_weight..max_weight))
         .collect();
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -10,7 +10,7 @@ use ::sprs::CsMat;
 /// Struct that represents a graph
 pub struct Graph{
     /// The CsMat (from sprs) is used to store the graph as a sparse matrix in CSR format
-    pub graph_csr: CsMat<f64>
+    pub graph_csr: CsMat<i64>
 }
 
 impl Graph {
@@ -34,18 +34,18 @@ impl Graph {
     }
 
     /// An iterator over the neighbors of the given vertex.
-    pub fn neighbors(&self, vertex: usize) -> Zip<Cloned<Iter<'_, usize>>, Cloned<Iter<'_, f64>>> {
+    pub fn neighbors(&self, vertex: usize) -> Zip<Cloned<Iter<'_, usize>>, Cloned<Iter<'_, i64>>> {
         let (indices, data) = self.graph_csr.outer_view(vertex).unwrap().into_raw_storage();
         indices.iter().cloned().zip(data.iter().cloned())
     }
 
     /// Insert an edge with two vertices on either ends.
-    pub fn insert(&mut self, vertex1: usize, vertex2: usize, edge_weight: f64) {
+    pub fn insert(&mut self, vertex1: usize, vertex2: usize, edge_weight: i64) {
         self.graph_csr.insert(vertex1, vertex2, edge_weight);
     }
 
     /// Get edge weight for a pair of vertices.
-    pub fn get_edge_weight(&self, vertex1: usize, vertex2: usize) -> Option<f64> {
+    pub fn get_edge_weight(&self, vertex1: usize, vertex2: usize) -> Option<i64> {
         self.graph_csr.get(vertex1, vertex2).cloned()
     }
 
@@ -67,7 +67,7 @@ impl Graph {
     ///    1*  ┆╲ ╱
     ///          * 0
     /// ```
-    pub fn edge_cut(&self, partition: &[usize]) -> f64
+    pub fn edge_cut(&self, partition: &[usize]) -> i64
     {
         debug_assert_eq!(self.len(), partition.len());
 
@@ -88,7 +88,7 @@ impl Graph {
                     .take_while(|(neighbor, _edge_weight)| **neighbor < vertex)
                     .filter(|(neighbor, _edge_weight)| vertex_part != partition[**neighbor])
                     .map(|(_neighbor, edge_weight)| *edge_weight)
-                    .sum::<f64>()
+                    .sum::<i64>()
             })
             .sum()
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -13,7 +13,7 @@ pub fn read_matrix_market_as_graph(file_path: &Path) -> Graph{
     }
 
     // Attempt to read the matrix market file as a TriMat with edge lengths as f64.
-    let tri_matrix_f64: Result<TriMatI<f64, usize>, _> = read_matrix_market(file_path);
+    let tri_matrix_f64: Result<TriMatI<i64, usize>, _> = read_matrix_market(file_path);
 
     match tri_matrix_f64 {
 
@@ -25,25 +25,7 @@ pub fn read_matrix_market_as_graph(file_path: &Path) -> Graph{
             }
         },
         Err(E) => {
-            // Read was unsuccessful, hence we try reading as a TriMat with edge lengths as i64.
-            let tri_matrix_i64: TriMatI<i64, usize> = read_matrix_market(file_path)
-                .expect("Failed to read matrix market file as both f64 and i64.");
-            let rows = tri_matrix_i64.rows();
-            let cols = tri_matrix_i64.cols();
-            let mut tri_matrix_f64 = TriMatI::new((rows, cols));
-            let iters = tri_matrix_i64.triplet_iter();
-            let row_indices = iters.clone().into_row_inds();
-            let col_indices = iters.clone().into_col_inds();
-            let data = iters.clone().into_data();
-
-            // Convert the edge lengths of TriMat from i64 to f64.
-            for ((row, col), value) in row_indices.zip(col_indices).zip(data) {
-                tri_matrix_f64.add_triplet(*row, *col, *value as f64);
-            }
-            // Convert to CSR and return it.
-            Graph {
-                graph_csr: tri_matrix_f64.to_csr(),
-            }
+            panic!("Error reading the matrix market file.");
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,22 @@
+use std::path::Path;
+use std::time::Instant;
+use GraphCut::algorithms::{MultiLevelPartitioner};
+use GraphCut::gen_weights::gen_uniform_weights;
+use GraphCut::imbalance::imbalance;
+use GraphCut::io::read_matrix_market_as_graph;
+use GraphCut::Partition;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let graph = read_matrix_market_as_graph(Path::new("./testdata/vt2010.mtx"));
+    let weights = gen_uniform_weights(graph.len());
+    let mut partition = vec![0; graph.len()];
+    let start = Instant::now();
+    MultiLevelPartitioner {jet_iterations: 12, jet_tolerance_factor: 0.999, ..Default::default()}.partition(&mut partition, (graph.clone(), &weights))?;
+    let elapsed_time = start.elapsed();
+    let edge_cut = graph.edge_cut(&partition);
+    let imbalance_of_partition = imbalance(2, &partition, weights.clone());
+    println!("Edge cut {:?}", edge_cut);
+    println!("Imbalance {:?}", imbalance_of_partition);
+    println!("Execution time {:?}", elapsed_time);
+    Ok(())
+}


### PR DESCRIPTION
Primary savings came from the following 2 optimizations
1. Made the construction of coarse graphs more efficient
2. Precomputed weight of the partition to use in jetrw

Other minor optimizations

1. Removed unnecessary clones
2. Minor changes to data structures
3. Avoided repeated creation of Random seed object

